### PR TITLE
UI Restructuring

### DIFF
--- a/components/font_image/font_image.gd
+++ b/components/font_image/font_image.gd
@@ -117,16 +117,16 @@ func set_wireframe(options: Dictionary) -> void:
 	if options.has("char_width") and int(options["char_width"]) != char_dimensions.x:
 		char_dimensions.x = options.char_width
 		char_counts.x = get_horizontal_char_count()
-		#update()
+		queue_redraw()
 	
 	if options.has("char_height") and int(options["char_height"]) != char_dimensions.y:
 		char_dimensions.y = options.char_height
 		char_counts.y = get_vertical_char_count()
-		#update()
+		queue_redraw()
 		
 	if options.has("base_from_top") and int(options["base_from_top"]) != base_offset:
 		base_offset = options.base_from_top
-		#update()
+		queue_redraw()
 
 
 func set_image(tex: Texture) -> void:

--- a/components/font_image/font_image.tscn
+++ b/components/font_image/font_image.tscn
@@ -3,4 +3,5 @@
 [ext_resource type="Script" path="res://components/font_image/font_image.gd" id="2"]
 
 [node name="FontImage" type="Sprite2D"]
+texture_filter = 1
 script = ExtResource("2")

--- a/components/main_camera/main_camera.tscn
+++ b/components/main_camera/main_camera.tscn
@@ -1,7 +1,6 @@
-[gd_scene format=2]
+[gd_scene format=3 uid="uid://du4stbhogas0i"]
 
 [node name="MainCamera" type="Camera2D"]
-current = true
 limit_left = 5000
 limit_top = 5000
 limit_right = 5000

--- a/components/user_interface/components/horizontal_margin.tscn
+++ b/components/user_interface/components/horizontal_margin.tscn
@@ -1,9 +1,0 @@
-[gd_scene format=2]
-
-[node name="HorizontalMargin" type="MarginContainer"]
-margin_right = 40.0
-margin_bottom = 40.0
-custom_constants/margin_right = 5
-__meta__ = {
-"_edit_use_anchors_": false
-}

--- a/components/user_interface/components/vertical_margin.tscn
+++ b/components/user_interface/components/vertical_margin.tscn
@@ -1,9 +1,0 @@
-[gd_scene format=2]
-
-[node name="VerticalMargin" type="MarginContainer"]
-margin_right = 40.0
-margin_bottom = 40.0
-custom_constants/margin_bottom = 15
-__meta__ = {
-"_edit_use_anchors_": false
-}

--- a/components/user_interface/user_interface.gd
+++ b/components/user_interface/user_interface.gd
@@ -20,63 +20,31 @@ var current_char_index: int = 0
 
 var texture_file_extension: String = ""
 
-@onready var open_file_dialog = $"TextureInfoControl/OpenFile"
+@onready var open_file_dialog = %OpenFile
 
-@onready var current_char_rect = $"LetterControl/Items/Panel/Controls/Texture/Panel/Char"
-@onready var current_char_advance = $"LetterControl/Items/Panel/Controls/Texture/Panel/Advance"
-@onready var decrease_advance_button = $"LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/Buttons/Decrease"
-@onready var increase_advance_button = $"LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/Buttons/Increase"
-@onready var current_advance_edit = $"LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/Edit/CurrentAdvance"
-@onready var advance_limit_label = $"LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/Edit/AdvanceLimit"
-@onready var prev_char_button = $"LetterControl/Items/Panel/Controls/LetterSwitch/Centering/Controls/PrevChar"
-@onready var next_char_button = $"LetterControl/Items/Panel/Controls/LetterSwitch/Centering/Controls/NextChar"
-@onready var current_char_edit = $"LetterControl/Items/Panel/Controls/LetterSwitch/Centering/Controls/CurrentChar"
-@onready var char_count_label = $"LetterControl/Items/Panel/Controls/LetterSwitch/Centering/Controls/CharCount"
+@onready var current_char_rect = %SelectedChar
+@onready var current_char_advance = %CurrentAdvance
+@onready var current_advance_edit = %CurrentAdvanceEdit
+@onready var advance_limit_label = %AdvanceLimit
+@onready var current_char_edit = %CurrentChar
+@onready var char_count_label = %CharCount
 
-@onready var image_load_button = $"TextureInfoControl/Panel/Margin/Scroll/Items/ImageLoad"
-@onready var font_name_edit = $"TextureInfoControl/Panel/Margin/Scroll/Items/FontNameEdit"
-@onready var texture_name_edit = $"TextureInfoControl/Panel/Margin/Scroll/Items/TextureNameEdit"
-@onready var char_width_edit = $"TextureInfoControl/Panel/Margin/Scroll/Items/CharacterDimensions/CharacterWidthEdit"
-@onready var char_height_edit = $"TextureInfoControl/Panel/Margin/Scroll/Items/CharacterDimensions/CharacterHeightEdit"
-@onready var decrease_base_button = $"TextureInfoControl/Panel/Margin/Scroll/Items/BaseSettings/DecreaseButton"
-@onready var increase_base_button = $"TextureInfoControl/Panel/Margin/Scroll/Items/BaseSettings/IncreaseButton"
-@onready var base_value_edit = $"TextureInfoControl/Panel/Margin/Scroll/Items/BaseSettings/BaseValue"
-@onready var char_list_edit = $"TextureInfoControl/Panel/Margin/Scroll/Items/CharacterListEdit"
-@onready var export_button = $"TextureInfoControl/Panel/Margin/Scroll/Items/ExportButton"
-@onready var export_as_xml_button = $"TextureInfoControl/Panel/Margin/Scroll/Items/ExportAsXMLButton"
+@onready var font_name_edit = %FontNameEdit
+@onready var texture_name_edit = %TextureNameEdit
+@onready var char_width_edit = %CharWidthEdit
+@onready var char_height_edit = %CharHeightEdit
+@onready var base_value_edit = %BaseValue
+@onready var char_list_edit = %CharListEdit
 
-@onready var info_dialog = $"InfoDialog"
-@onready var overwrite_dialog = $"FntOverwriteConfirmation"
+@onready var info_dialog = %InfoDialog
+@onready var overwrite_dialog = %OverwriteConfirmation
+
+@onready var advance_panel = %AdvancePanel
+@onready var font_info_panel = %FontInfo
+
 
 func _ready() -> void:
-	open_file_dialog.connect("file_selected", _on_file_selected)
-	
-	image_load_button.connect("pressed", _on_image_load_button_pressed)
-	char_width_edit.connect("focus_exited", _on_char_width_edit_focus_exited)
-	char_height_edit.connect("focus_exited", _on_char_height_edit_focus_exited)
-	
-	current_advance_edit.connect("focus_exited", _on_char_advance_edit_focus_exited)
-	current_char_edit.connect("focus_exited", _on_current_char_edit_focus_exited)
-	
-	decrease_base_button.connect("pressed", _on_decrease_base_button_pressed)
-	increase_base_button.connect("pressed", _on_increase_base_button_pressed)
-	base_value_edit.connect("focus_exited", _on_base_value_edit_focus_exited)
-	export_button.connect("pressed", _on_export_button_pressed)
-	export_as_xml_button.connect("pressed", _on_export_as_xml_button_pressed)
-	
-	decrease_advance_button.connect("pressed", _on_decrease_advance_button_pressed)
-	increase_advance_button.connect("pressed", _on_increase_advance_button_pressed)
-	#current_advance_edit.connect("text_changed", _on_current_advance_edit_text_changed)
-	prev_char_button.connect("pressed", _on_prev_char_button_pressed)
-	next_char_button.connect("pressed", _on_next_char_button_pressed)
-	#current_char_edit.connect("text_changed", _on_current_char_edit_text_changed)
-	
-	#texture_name_edit.connect("focus_exited", _on_texture_name_edit_focus_exited)
-	
-	
 	_unlock_edit_buttons(false)
-	
-	texture_name_edit.editable = false
 	
 	current_char_atlas = AtlasTexture.new()
 	
@@ -118,21 +86,8 @@ func open_dialog(message: String) -> void:
 
 
 func _unlock_edit_buttons(value: bool) -> void:
-	char_width_edit.editable = value
-	char_height_edit.editable = value
-	decrease_base_button.disabled = !value
-	increase_base_button.disabled = !value
-	decrease_advance_button.disabled = !value
-	increase_advance_button.disabled = !value
-	base_value_edit.editable = value
-	export_button.disabled = !value
-	current_advance_edit.editable = value
-	prev_char_button.disabled = !value
-	next_char_button.disabled = !value
-	current_char_edit.editable = value
-	font_name_edit.editable = value
-	char_list_edit.editable = value
-	export_button.disabled = !value
+	advance_panel.visible = value
+	font_info_panel.visible = value
 
 
 func _on_file_selected(file_path: String) -> void:
@@ -171,7 +126,7 @@ func _on_file_selected(file_path: String) -> void:
 			
 		_unlock_edit_buttons(true)
 		
-		emit_signal("file_selected", texture_info)
+		file_selected.emit(texture_info)
 	else:
 		open_dialog(tr("FILE_IS_NOT_TEXTURE"))
 
@@ -208,7 +163,7 @@ func _on_char_advance_edit_focus_exited() -> void:
 	
 	_update_current_visible_char()
 	
-	emit_signal("form_field_updated", {
+	form_field_updated.emit({
 		"current_char_advance": advance_infos[current_char_index],
 	})
 
@@ -219,7 +174,7 @@ func _on_current_char_edit_focus_exited() -> void:
 	
 	_update_current_visible_char()
 	
-	emit_signal("selected_char_index_changed", current_char_index, advance_infos[current_char_index])
+	selected_char_index_changed.emit(current_char_index, advance_infos[current_char_index])
 
 
 func _on_char_width_edit_focus_exited() -> void:
@@ -238,7 +193,7 @@ func _on_char_width_edit_focus_exited() -> void:
 		
 	_update_current_visible_char()
 	
-	emit_signal("form_field_updated", {
+	form_field_updated.emit({
 		"char_width": char_width,
 	})
 
@@ -254,19 +209,19 @@ func _on_char_height_edit_focus_exited() -> void:
 	
 	_update_current_visible_char()
 	
-	emit_signal("form_field_updated", {
+	form_field_updated.emit({
 		"char_height": char_height,
 	})
 
 
 func _on_decrease_base_button_pressed() -> void:
 	base_value_edit.text = str(max(0, int(base_value_edit.text) - 1))
-	emit_signal("form_field_updated", {"base_from_top": int(base_value_edit.text)})
+	form_field_updated.emit({"base_from_top": int(base_value_edit.text)})
 
 
 func _on_increase_base_button_pressed() -> void:
 	base_value_edit.text = str(min(int(base_value_edit.text) + 1, int(char_height_edit.text)))
-	emit_signal("form_field_updated", {"base_from_top": int(base_value_edit.text)})
+	form_field_updated.emit({"base_from_top": int(base_value_edit.text)})
 
 
 func _on_increase_advance_button_pressed() -> void:
@@ -277,7 +232,7 @@ func _on_increase_advance_button_pressed() -> void:
 		
 	_update_current_visible_char()
 	
-	emit_signal("form_field_updated", {
+	form_field_updated.emit({
 		"current_char_advance": advance_infos[current_char_index],
 	})
 
@@ -290,7 +245,7 @@ func _on_decrease_advance_button_pressed() -> void:
 	
 	_update_current_visible_char()
 	
-	emit_signal("form_field_updated", {
+	form_field_updated.emit({
 		"current_char_advance": advance_infos[current_char_index],
 	})
 
@@ -298,7 +253,7 @@ func _on_decrease_advance_button_pressed() -> void:
 func _on_prev_char_button_pressed() -> void:
 	current_char_index = max(0, current_char_index - 1)
 	current_char_index = min((char_counts.x * char_counts.y) - 1, current_char_index)
-	emit_signal("selected_char_index_changed", current_char_index, advance_infos[current_char_index])
+	selected_char_index_changed.emit(current_char_index, advance_infos[current_char_index])
 	
 	current_char_edit.text = str(current_char_index)
 	
@@ -307,7 +262,7 @@ func _on_prev_char_button_pressed() -> void:
 
 func _on_next_char_button_pressed() -> void:
 	current_char_index = min((char_counts.x * char_counts.y) - 1, current_char_index + 1)
-	emit_signal("selected_char_index_changed", current_char_index, advance_infos[current_char_index])
+	selected_char_index_changed.emit(current_char_index, advance_infos[current_char_index])
 	
 	current_char_edit.text = str(current_char_index)
 	
@@ -321,7 +276,7 @@ func _on_base_value_edit_focus_exited() -> void:
 	
 	base_value_edit.text = str(parsed_value)
 	
-	emit_signal("form_field_updated", {"base_from_top": parsed_value})
+	form_field_updated.emit({"base_from_top": parsed_value})
 
 
 func _get_export_values():
@@ -340,10 +295,10 @@ func _get_export_values():
 func _on_export_button_pressed() -> void:
 	var export_values = _get_export_values()
 	
-	emit_signal("export_button_pressed", export_values)
+	export_button_pressed.emit(export_values)
 
 
 func _on_export_as_xml_button_pressed() -> void:
 	var export_values = _get_export_values()
 	
-	emit_signal("export_as_xml_button_pressed", export_values)
+	export_as_xml_button_pressed.emit(export_values)

--- a/components/user_interface/user_interface.tscn
+++ b/components/user_interface/user_interface.tscn
@@ -295,7 +295,6 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 36)
 layout_mode = 2
 size_flags_vertical = 3
-selecting_enabled = false
 wrap_mode = 1
 autowrap_mode = 1
 

--- a/components/user_interface/user_interface.tscn
+++ b/components/user_interface/user_interface.tscn
@@ -1,8 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://rcj2mnv6rwrf"]
+[gd_scene load_steps=3 format=3 uid="uid://rcj2mnv6rwrf"]
 
 [ext_resource type="Script" path="res://components/user_interface/user_interface.gd" id="2"]
-[ext_resource type="PackedScene" path="res://components/user_interface/components/vertical_margin.tscn" id="4"]
-[ext_resource type="PackedScene" path="res://components/user_interface/components/horizontal_margin.tscn" id="5"]
 
 [sub_resource type="AtlasTexture" id="1"]
 
@@ -14,147 +12,134 @@ mouse_filter = 2
 alignment = 2
 script = ExtResource("2")
 
-[node name="LetterControl" type="MarginContainer" parent="."]
+[node name="AdvancePanel" type="PanelContainer" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 0
+
+[node name="LetterControl" type="MarginContainer" parent="AdvancePanel"]
 layout_mode = 2
 
-[node name="Items" type="VBoxContainer" parent="LetterControl"]
+[node name="Controls" type="VBoxContainer" parent="AdvancePanel/LetterControl"]
 layout_mode = 2
+theme_override_constants/separation = 8
 
-[node name="Panel" type="PanelContainer" parent="LetterControl/Items"]
-layout_mode = 2
-
-[node name="Controls" type="VBoxContainer" parent="LetterControl/Items/Panel"]
-layout_mode = 2
-
-[node name="Texture" type="HBoxContainer" parent="LetterControl/Items/Panel/Controls"]
+[node name="Texture" type="HBoxContainer" parent="AdvancePanel/LetterControl/Controls"]
 layout_mode = 2
 alignment = 1
 
-[node name="Panel" type="PanelContainer" parent="LetterControl/Items/Panel/Controls/Texture"]
+[node name="Panel" type="PanelContainer" parent="AdvancePanel/LetterControl/Controls/Texture"]
 self_modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="Char" type="TextureRect" parent="LetterControl/Items/Panel/Controls/Texture/Panel"]
+[node name="SelectedChar" type="TextureRect" parent="AdvancePanel/LetterControl/Controls/Texture/Panel"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 texture = SubResource("1")
 
-[node name="Advance" type="ColorRect" parent="LetterControl/Items/Panel/Controls/Texture/Panel"]
+[node name="CurrentAdvance" type="ColorRect" parent="AdvancePanel/LetterControl/Controls/Texture/Panel"]
+unique_name_in_owner = true
 modulate = Color(1, 1, 1, 0.498039)
 layout_mode = 2
 size_flags_horizontal = 0
 
-[node name="AdvanceControls" type="HBoxContainer" parent="LetterControl/Items/Panel/Controls"]
+[node name="Items" type="VBoxContainer" parent="AdvancePanel/LetterControl/Controls"]
 layout_mode = 2
 
-[node name="Centering" type="CenterContainer" parent="LetterControl/Items/Panel/Controls/AdvanceControls"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="Items" type="VBoxContainer" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering"]
-layout_mode = 2
-
-[node name="HorizontalMargin" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items" instance=ExtResource("5")]
-layout_mode = 2
-
-[node name="TextAdvance" type="HBoxContainer" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items"]
-layout_mode = 2
-
-[node name="XAdvance" type="Label" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/TextAdvance"]
+[node name="XAdvance" type="Label" parent="AdvancePanel/LetterControl/Controls/Items"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "X Advance"
 horizontal_alignment = 1
 
-[node name="Edit" type="HBoxContainer" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items"]
+[node name="Edit" type="HBoxContainer" parent="AdvancePanel/LetterControl/Controls/Items"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="CurrentAdvance" type="LineEdit" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/Edit"]
+[node name="CurrentAdvanceEdit" type="LineEdit" parent="AdvancePanel/LetterControl/Controls/Items/Edit"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "0"
 
-[node name="Pixels2" type="Label" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/Edit"]
+[node name="Pixels2" type="Label" parent="AdvancePanel/LetterControl/Controls/Items/Edit"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "px"
 horizontal_alignment = 1
 
-[node name="Slash" type="Label" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/Edit"]
+[node name="Slash" type="Label" parent="AdvancePanel/LetterControl/Controls/Items/Edit"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "/"
 horizontal_alignment = 1
 
-[node name="AdvanceLimit" type="Label" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/Edit"]
+[node name="AdvanceLimit" type="Label" parent="AdvancePanel/LetterControl/Controls/Items/Edit"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "10"
 horizontal_alignment = 1
 
-[node name="Pixels" type="Label" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/Edit"]
+[node name="Pixels" type="Label" parent="AdvancePanel/LetterControl/Controls/Items/Edit"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "px"
 horizontal_alignment = 1
 
-[node name="Buttons" type="HBoxContainer" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items"]
+[node name="Buttons" type="HBoxContainer" parent="AdvancePanel/LetterControl/Controls/Items"]
 layout_mode = 2
 
-[node name="Decrease" type="Button" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/Buttons"]
+[node name="Decrease" type="Button" parent="AdvancePanel/LetterControl/Controls/Items/Buttons"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "<"
 
-[node name="Increase" type="Button" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/Buttons"]
+[node name="Increase" type="Button" parent="AdvancePanel/LetterControl/Controls/Items/Buttons"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = ">"
 
-[node name="HorizontalMargin2" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items" instance=ExtResource("5")]
-layout_mode = 2
-
-[node name="TextChars" type="HBoxContainer" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items"]
-layout_mode = 2
-
-[node name="Index" type="Label" parent="LetterControl/Items/Panel/Controls/AdvanceControls/Centering/Items/TextChars"]
+[node name="Index" type="Label" parent="AdvancePanel/LetterControl/Controls"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "CURRENT_CHAR_INDEX"
 horizontal_alignment = 1
 
-[node name="LetterSwitch" type="HBoxContainer" parent="LetterControl/Items/Panel/Controls"]
+[node name="LetterSwitch" type="HBoxContainer" parent="AdvancePanel/LetterControl/Controls"]
 layout_mode = 2
 alignment = 1
 
-[node name="Centering" type="CenterContainer" parent="LetterControl/Items/Panel/Controls/LetterSwitch"]
+[node name="Centering" type="CenterContainer" parent="AdvancePanel/LetterControl/Controls/LetterSwitch"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Controls" type="HBoxContainer" parent="LetterControl/Items/Panel/Controls/LetterSwitch/Centering"]
+[node name="Controls" type="HBoxContainer" parent="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering"]
 layout_mode = 2
 
-[node name="PrevChar" type="Button" parent="LetterControl/Items/Panel/Controls/LetterSwitch/Centering/Controls"]
+[node name="PrevChar" type="Button" parent="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering/Controls"]
 layout_mode = 2
 text = "<"
 
-[node name="CurrentChar" type="LineEdit" parent="LetterControl/Items/Panel/Controls/LetterSwitch/Centering/Controls"]
+[node name="CurrentChar" type="LineEdit" parent="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering/Controls"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "0"
 
-[node name="Slash" type="Label" parent="LetterControl/Items/Panel/Controls/LetterSwitch/Centering/Controls"]
+[node name="Slash" type="Label" parent="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering/Controls"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "/"
 
-[node name="CharCount" type="Label" parent="LetterControl/Items/Panel/Controls/LetterSwitch/Centering/Controls"]
+[node name="CharCount" type="Label" parent="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering/Controls"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "10"
 
-[node name="NextChar" type="Button" parent="LetterControl/Items/Panel/Controls/LetterSwitch/Centering/Controls"]
+[node name="NextChar" type="Button" parent="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering/Controls"]
 layout_mode = 2
 text = ">"
 
@@ -162,144 +147,193 @@ text = ">"
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TextureInfoControl" type="MarginContainer" parent="."]
+[node name="RightSide" type="VBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="OpenFile" type="FileDialog" parent="TextureInfoControl"]
-access = 2
-
-[node name="Panel" type="PanelContainer" parent="TextureInfoControl"]
+[node name="TextureInfo" type="PanelContainer" parent="RightSide"]
 layout_mode = 2
 
-[node name="Margin" type="MarginContainer" parent="TextureInfoControl/Panel"]
+[node name="Margin" type="MarginContainer" parent="RightSide/TextureInfo"]
 layout_mode = 2
 
-[node name="Scroll" type="ScrollContainer" parent="TextureInfoControl/Panel/Margin"]
+[node name="Items" type="VBoxContainer" parent="RightSide/TextureInfo/Margin"]
 layout_mode = 2
-horizontal_scroll_mode = 0
-
-[node name="Items" type="VBoxContainer" parent="TextureInfoControl/Panel/Margin/Scroll"]
-layout_mode = 2
+size_flags_horizontal = 3
 size_flags_vertical = 3
+theme_override_constants/separation = 8
 
-[node name="ProjectTitle" type="Label" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="Title" type="VBoxContainer" parent="RightSide/TextureInfo/Margin/Items"]
+layout_mode = 2
+
+[node name="ProjectTitle" type="Label" parent="RightSide/TextureInfo/Margin/Items/Title"]
 layout_mode = 2
 text = "PROJECT_NAME"
 
-[node name="VMarginTitle" parent="TextureInfoControl/Panel/Margin/Scroll/Items" instance=ExtResource("4")]
-layout_mode = 2
-
-[node name="ImageLoad" type="Button" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="ImageLoad" type="Button" parent="RightSide/TextureInfo/Margin/Items/Title"]
 layout_mode = 2
 text = "LOAD_AN_IMAGE"
 
-[node name="VMarginLoad" parent="TextureInfoControl/Panel/Margin/Scroll/Items" instance=ExtResource("4")]
+[node name="FontName" type="VBoxContainer" parent="RightSide/TextureInfo/Margin/Items"]
 layout_mode = 2
 
-[node name="FontNameLabel" type="Label" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="FontNameLabel" type="Label" parent="RightSide/TextureInfo/Margin/Items/FontName"]
 layout_mode = 2
 text = "FONT_NAME"
 
-[node name="FontNameEdit" type="LineEdit" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="FontNameEdit" type="LineEdit" parent="RightSide/TextureInfo/Margin/Items/FontName"]
+unique_name_in_owner = true
 layout_mode = 2
 
-[node name="VMarginFont" parent="TextureInfoControl/Panel/Margin/Scroll/Items" instance=ExtResource("4")]
+[node name="TextureName" type="VBoxContainer" parent="RightSide/TextureInfo/Margin/Items"]
 layout_mode = 2
 
-[node name="TextureNameLabel" type="Label" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="TextureNameLabel" type="Label" parent="RightSide/TextureInfo/Margin/Items/TextureName"]
 layout_mode = 2
 text = "TEXTURE_NAME"
 
-[node name="TextureNameEdit" type="LineEdit" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="TextureNameEdit" type="LineEdit" parent="RightSide/TextureInfo/Margin/Items/TextureName"]
+unique_name_in_owner = true
+layout_mode = 2
+editable = false
+
+[node name="FontInfo" type="PanelContainer" parent="RightSide"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Scroll" type="ScrollContainer" parent="RightSide/FontInfo"]
+layout_mode = 2
+horizontal_scroll_mode = 0
+
+[node name="Margin" type="MarginContainer" parent="RightSide/FontInfo/Scroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Items" type="VBoxContainer" parent="RightSide/FontInfo/Scroll/Margin"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="CharDimensions" type="VBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items"]
 layout_mode = 2
 
-[node name="VMarginTexture" parent="TextureInfoControl/Panel/Margin/Scroll/Items" instance=ExtResource("4")]
-layout_mode = 2
-
-[node name="CharacterDimensionsLabel" type="Label" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="CharDimensionsLabel" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions"]
 layout_mode = 2
 text = "CHAR_DIMENSIONS"
 
-[node name="CharacterDimensions" type="HBoxContainer" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="CharDimensions" type="HBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="X" type="HBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions"]
 layout_mode = 2
 
-[node name="CharacterWidthEdit" type="LineEdit" parent="TextureInfoControl/Panel/Margin/Scroll/Items/CharacterDimensions"]
+[node name="CharWidthEdit" type="LineEdit" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/X"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "1"
 
-[node name="Pixels" type="Label" parent="TextureInfoControl/Panel/Margin/Scroll/Items/CharacterDimensions"]
+[node name="Pixels" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/X"]
 layout_mode = 2
 text = "px"
 
-[node name="HMarginX" parent="TextureInfoControl/Panel/Margin/Scroll/Items/CharacterDimensions" instance=ExtResource("5")]
-layout_mode = 2
-
-[node name="Times" type="Label" parent="TextureInfoControl/Panel/Margin/Scroll/Items/CharacterDimensions"]
+[node name="Times" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions"]
 layout_mode = 2
 text = "X"
 
-[node name="HMarginY" parent="TextureInfoControl/Panel/Margin/Scroll/Items/CharacterDimensions" instance=ExtResource("5")]
+[node name="Y" type="HBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions"]
 layout_mode = 2
 
-[node name="CharacterHeightEdit" type="LineEdit" parent="TextureInfoControl/Panel/Margin/Scroll/Items/CharacterDimensions"]
+[node name="CharHeightEdit" type="LineEdit" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/Y"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "1"
 
-[node name="Pixels2" type="Label" parent="TextureInfoControl/Panel/Margin/Scroll/Items/CharacterDimensions"]
+[node name="Pixels" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/Y"]
 layout_mode = 2
 text = "px"
 
-[node name="VMarginChar" parent="TextureInfoControl/Panel/Margin/Scroll/Items" instance=ExtResource("4")]
+[node name="BaseFromTop" type="VBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items"]
 layout_mode = 2
 
-[node name="BaseFromTopLabel" type="Label" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="BaseFromTopLabel" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop"]
 layout_mode = 2
 text = "BASE_FROM_TOP"
 
-[node name="BaseSettings" type="HBoxContainer" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="BaseSettings" type="HBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop"]
 layout_mode = 2
 
-[node name="DecreaseButton" type="Button" parent="TextureInfoControl/Panel/Margin/Scroll/Items/BaseSettings"]
+[node name="DecreaseButton" type="Button" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings"]
 layout_mode = 2
 text = "<"
 
-[node name="BaseValue" type="LineEdit" parent="TextureInfoControl/Panel/Margin/Scroll/Items/BaseSettings"]
+[node name="BaseValue" type="LineEdit" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "0"
 
-[node name="Pixels3" type="Label" parent="TextureInfoControl/Panel/Margin/Scroll/Items/BaseSettings"]
+[node name="Pixels3" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings"]
 layout_mode = 2
 text = "px"
 
-[node name="IncreaseButton" type="Button" parent="TextureInfoControl/Panel/Margin/Scroll/Items/BaseSettings"]
+[node name="IncreaseButton" type="Button" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings"]
 layout_mode = 2
 text = ">"
 
-[node name="BaseFromTopMargin" parent="TextureInfoControl/Panel/Margin/Scroll/Items" instance=ExtResource("5")]
+[node name="CharList" type="VBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items"]
 layout_mode = 2
+size_flags_vertical = 3
 
-[node name="CharacterListLabel" type="Label" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="CharListLabel" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/CharList"]
 layout_mode = 2
 text = "CHAR_LIST"
 
-[node name="CharacterListEdit" type="TextEdit" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="CharListEdit" type="TextEdit" parent="RightSide/FontInfo/Scroll/Margin/Items/CharList"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 36)
 layout_mode = 2
 size_flags_vertical = 3
 selecting_enabled = false
+wrap_mode = 1
+autowrap_mode = 1
 
-[node name="VMarginCharList" parent="TextureInfoControl/Panel/Margin/Scroll/Items" instance=ExtResource("4")]
+[node name="Export" type="VBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items"]
 layout_mode = 2
 
-[node name="ExportButton" type="Button" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="ExportButton" type="Button" parent="RightSide/FontInfo/Scroll/Margin/Items/Export"]
 layout_mode = 2
 text = "EXPORT_FNT"
 
-[node name="ExportAsXMLButton" type="Button" parent="TextureInfoControl/Panel/Margin/Scroll/Items"]
+[node name="ExportAsXMLButton" type="Button" parent="RightSide/FontInfo/Scroll/Margin/Items/Export"]
 layout_mode = 2
 text = "EXPORT_FNT_AS_XML"
 
+[node name="OpenFile" type="FileDialog" parent="."]
+unique_name_in_owner = true
+access = 2
+
 [node name="InfoDialog" type="AcceptDialog" parent="."]
+unique_name_in_owner = true
 dialog_text = "Dialog message."
 
-[node name="FntOverwriteConfirmation" type="ConfirmationDialog" parent="."]
+[node name="OverwriteConfirmation" type="ConfirmationDialog" parent="."]
+unique_name_in_owner = true
 dialog_text = "FILE_EXISTS"
+
+[connection signal="focus_exited" from="AdvancePanel/LetterControl/Controls/Items/Edit/CurrentAdvanceEdit" to="." method="_on_char_advance_edit_focus_exited"]
+[connection signal="pressed" from="AdvancePanel/LetterControl/Controls/Items/Buttons/Decrease" to="." method="_on_decrease_advance_button_pressed"]
+[connection signal="pressed" from="AdvancePanel/LetterControl/Controls/Items/Buttons/Increase" to="." method="_on_increase_advance_button_pressed"]
+[connection signal="pressed" from="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering/Controls/PrevChar" to="." method="_on_prev_char_button_pressed"]
+[connection signal="focus_exited" from="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering/Controls/CurrentChar" to="." method="_on_current_char_edit_focus_exited"]
+[connection signal="pressed" from="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering/Controls/NextChar" to="." method="_on_next_char_button_pressed"]
+[connection signal="pressed" from="RightSide/TextureInfo/Margin/Items/Title/ImageLoad" to="." method="_on_image_load_button_pressed"]
+[connection signal="focus_exited" from="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/X/CharWidthEdit" to="." method="_on_char_width_edit_focus_exited"]
+[connection signal="focus_exited" from="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/Y/CharHeightEdit" to="." method="_on_char_height_edit_focus_exited"]
+[connection signal="pressed" from="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings/DecreaseButton" to="." method="_on_decrease_base_button_pressed"]
+[connection signal="focus_exited" from="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings/BaseValue" to="." method="_on_base_value_edit_focus_exited"]
+[connection signal="pressed" from="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings/IncreaseButton" to="." method="_on_increase_base_button_pressed"]
+[connection signal="pressed" from="RightSide/FontInfo/Scroll/Margin/Items/Export/ExportButton" to="." method="_on_export_button_pressed"]
+[connection signal="pressed" from="RightSide/FontInfo/Scroll/Margin/Items/Export/ExportAsXMLButton" to="." method="_on_export_as_xml_button_pressed"]
+[connection signal="file_selected" from="OpenFile" to="." method="_on_file_selected"]

--- a/project.godot
+++ b/project.godot
@@ -23,6 +23,10 @@ config/icon="res://system/icon.png"
 window/size/width=900
 window/size/height=640
 
+[gui]
+
+theme/custom="res://system/default_theme.tres"
+
 [internationalization]
 
 locale/translations=PackedStringArray("res://translations/system.en.translation")

--- a/project.godot
+++ b/project.godot
@@ -40,4 +40,3 @@ translations=PackedStringArray("res://translations/system.en.translation")
 quality/driver/driver_name="GLES2"
 vram_compression/import_etc=true
 vram_compression/import_etc2=false
-environment/default_environment="res://system/default_env.tres"

--- a/scenes/main/main.gd
+++ b/scenes/main/main.gd
@@ -15,12 +15,12 @@ var fnt_file = null
 var current_export_type = ExportType.TEXT
 
 func _ready():
-	user_interface.connect("file_selected", _on_file_selected)
-	user_interface.connect("form_field_updated", _on_form_field_updated)
-	user_interface.connect("selected_char_index_changed", _on_selected_char_index_changed)
-	user_interface.connect("export_button_pressed", _on_export_button_pressed)
-	user_interface.connect("export_as_xml_button_pressed", _on_export_as_xml_button_pressed)
-	user_interface.overwrite_dialog.get_ok_button().connect("pressed", _on_overwrite_confirm_pressed)
+	user_interface.file_selected.connect(_on_file_selected)
+	user_interface.form_field_updated.connect(_on_form_field_updated)
+	user_interface.selected_char_index_changed.connect(_on_selected_char_index_changed)
+	user_interface.export_button_pressed.connect(_on_export_button_pressed)
+	user_interface.export_as_xml_button_pressed.connect(_on_export_as_xml_button_pressed)
+	user_interface.overwrite_dialog.get_ok_button().pressed.connect(_on_overwrite_confirm_pressed)
 
 
 func _on_overwrite_confirm_pressed():

--- a/scenes/main/main.gd
+++ b/scenes/main/main.gd
@@ -6,8 +6,8 @@ enum ExportType {
 	XML,
 }
 
-@onready var font_image = get_node("FontImage")
-@onready var user_interface = get_node("Controls/UserInterface")
+@onready var font_image = $FontImage
+@onready var user_interface = %UserInterface
 
 var export_directory = ""
 var export_file = ""
@@ -15,11 +15,6 @@ var fnt_file = null
 var current_export_type = ExportType.TEXT
 
 func _ready():
-	user_interface.file_selected.connect(_on_file_selected)
-	user_interface.form_field_updated.connect(_on_form_field_updated)
-	user_interface.selected_char_index_changed.connect(_on_selected_char_index_changed)
-	user_interface.export_button_pressed.connect(_on_export_button_pressed)
-	user_interface.export_as_xml_button_pressed.connect(_on_export_as_xml_button_pressed)
 	user_interface.overwrite_dialog.get_ok_button().pressed.connect(_on_overwrite_confirm_pressed)
 
 

--- a/scenes/main/main.tscn
+++ b/scenes/main/main.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://c7ei7qoakyrl"]
+[gd_scene load_steps=5 format=3 uid="uid://c7ei7qoakyrl"]
 
 [ext_resource type="Script" path="res://scenes/main/main.gd" id="1"]
-[ext_resource type="PackedScene" path="res://components/main_camera/main_camera.tscn" id="2"]
+[ext_resource type="PackedScene" uid="uid://du4stbhogas0i" path="res://components/main_camera/main_camera.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://ym16p8538k5m" path="res://components/font_image/font_image.tscn" id="3"]
-[ext_resource type="Texture2D" uid="uid://c5wea834mrek5" path="res://system/black_brush.png" id="3_66k1p"]
 [ext_resource type="PackedScene" uid="uid://rcj2mnv6rwrf" path="res://components/user_interface/user_interface.tscn" id="4"]
 
 [node name="Main" type="Node2D"]
@@ -11,7 +10,6 @@ script = ExtResource("1")
 
 [node name="FontImage" parent="." instance=ExtResource("3")]
 position = Vector2(378, 243)
-texture = ExtResource("3_66k1p")
 
 [node name="MainCamera" parent="FontImage" instance=ExtResource("2")]
 offset = Vector2(900, 0)

--- a/scenes/main/main.tscn
+++ b/scenes/main/main.tscn
@@ -21,3 +21,10 @@ limit_bottom = 0
 [node name="Controls" type="CanvasLayer" parent="."]
 
 [node name="UserInterface" parent="Controls" instance=ExtResource("4")]
+unique_name_in_owner = true
+
+[connection signal="export_as_xml_button_pressed" from="Controls/UserInterface" to="." method="_on_export_as_xml_button_pressed"]
+[connection signal="export_button_pressed" from="Controls/UserInterface" to="." method="_on_export_button_pressed"]
+[connection signal="file_selected" from="Controls/UserInterface" to="." method="_on_file_selected"]
+[connection signal="form_field_updated" from="Controls/UserInterface" to="." method="_on_form_field_updated"]
+[connection signal="selected_char_index_changed" from="Controls/UserInterface" to="." method="_on_selected_char_index_changed"]

--- a/system/default_env.tres
+++ b/system/default_env.tres
@@ -1,7 +1,0 @@
-[gd_resource type="Environment" load_steps=2 format=2]
-
-[sub_resource type="ProceduralSky" id=1]
-
-[resource]
-background_mode = 2
-background_sky = SubResource( 1 )

--- a/system/default_theme.tres
+++ b/system/default_theme.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Theme" format=3 uid="uid://dgb7h5x1rpwvn"]
+
+[resource]
+MarginContainer/constants/margin_bottom = 16
+MarginContainer/constants/margin_left = 16
+MarginContainer/constants/margin_right = 16
+MarginContainer/constants/margin_top = 16


### PR DESCRIPTION
General restructure of the main UI, with a number of effects:
- Margins for panels
- Split the right sidebar into two parts, one of which can be hidden and shown once a texture is loaded
- Simplified code by hiding UI elements rather than disabling each of the children individually
- Replaced manual `connect()` calls with connections via the scene editor
- Replaced `emit_signal()` calls with `signal.emit()`, resolving some warnings
- Replaced some long node paths (`$Path/To/Node`) with scene unique names (`%Node`)
- Removed some `@onready var`s made redundant by other changes
- Removed `vertical_margin.tscn` and `horizontal_margin.tscn`, using nested BoxContainers instead
- Fixed wireframe not updating when changing character size
- Disabled texture filtering on the font texture
- Enabled text selection in the Character List
- Gave the Character List a minimum vertical size to prevent it being crushed flat when resizing the window
- Applied a default theme, stored at `system/default_theme.tres`
- Removed `default_env.tres`

Apologies that this PR is so monolithic - now that the bulk of the restructuring is done, further PRs should be more granular.