### PR TITLE
Wireframe and selection changes

### DIFF
--- a/components/font_image/font_image.gd
+++ b/components/font_image/font_image.gd
@@ -27,7 +27,7 @@ func set_current_letter(index: int) -> void:
 	letter_indices.x = index % int(char_counts.x)
 	letter_indices.y = floor(index / char_counts.x)
 	
-	#update()
+	queue_redraw()
 
 
 func _input(event: InputEvent) -> void:
@@ -74,7 +74,7 @@ func _draw_letter_selection():
 
 
 func _draw_base_line():
-	for i in range(char_counts.y + 1):
+	for i in range(char_counts.y):
 		if i == char_counts.y + 1:
 			return
 		
@@ -107,7 +107,7 @@ func _draw_letter_separators():
 func set_current_char_advance(value: int) -> void:
 	current_char_advance = value
 	
-	#update()
+	queue_redraw()
 
 
 func set_wireframe(options: Dictionary) -> void:
@@ -142,7 +142,8 @@ func set_image(tex: Texture) -> void:
 	
 	is_texture_set = true
 	
-	#update()
+	# TODO: Is this required? Unsure what this is meant to do.
+	#queue_redraw()
 
 
 func set_char_width(value: int) -> void:

--- a/components/font_image/font_image.tscn
+++ b/components/font_image/font_image.tscn
@@ -2,6 +2,6 @@
 
 [ext_resource type="Script" path="res://components/font_image/font_image.gd" id="2"]
 
-[node name="FontImage" type="Sprite2D"]
+[node name="FontImage" type="TextureRect"]
 texture_filter = 1
 script = ExtResource("2")

--- a/components/main_camera/main_camera.tscn
+++ b/components/main_camera/main_camera.tscn
@@ -1,7 +1,3 @@
 [gd_scene format=3 uid="uid://du4stbhogas0i"]
 
 [node name="MainCamera" type="Camera2D"]
-limit_left = 5000
-limit_top = 5000
-limit_right = 5000
-limit_bottom = 5000

--- a/components/user_interface/user_interface.gd
+++ b/components/user_interface/user_interface.gd
@@ -251,21 +251,18 @@ func _on_decrease_advance_button_pressed() -> void:
 
 
 func _on_prev_char_button_pressed() -> void:
-	current_char_index = max(0, current_char_index - 1)
-	current_char_index = min((char_counts.x * char_counts.y) - 1, current_char_index)
-	selected_char_index_changed.emit(current_char_index, advance_infos[current_char_index])
-	
-	current_char_edit.text = str(current_char_index)
-	
-	_update_current_visible_char()
+	set_current_char_index(current_char_index - 1)
 
 
 func _on_next_char_button_pressed() -> void:
-	current_char_index = min((char_counts.x * char_counts.y) - 1, current_char_index + 1)
+	set_current_char_index(current_char_index + 1)
+
+
+## Set the selected character index
+func set_current_char_index(index: int) -> void:
+	current_char_index = clamp(index, 0, (char_counts.x * char_counts.y) - 1)
 	selected_char_index_changed.emit(current_char_index, advance_infos[current_char_index])
-	
 	current_char_edit.text = str(current_char_index)
-	
 	_update_current_visible_char()
 
 

--- a/components/user_interface/user_interface.tscn
+++ b/components/user_interface/user_interface.tscn
@@ -146,6 +146,7 @@ text = ">"
 [node name="SpaceFill" type="MarginContainer" parent="."]
 layout_mode = 2
 size_flags_horizontal = 3
+mouse_filter = 2
 
 [node name="RightSide" type="VBoxContainer" parent="."]
 layout_mode = 2

--- a/scenes/main/main.tscn
+++ b/scenes/main/main.tscn
@@ -9,14 +9,8 @@
 script = ExtResource("1")
 
 [node name="FontImage" parent="." instance=ExtResource("3")]
-position = Vector2(378, 243)
 
-[node name="MainCamera" parent="FontImage" instance=ExtResource("2")]
-offset = Vector2(900, 0)
-limit_left = 0
-limit_top = 0
-limit_right = 0
-limit_bottom = 0
+[node name="MainCamera" parent="." instance=ExtResource("2")]
 
 [node name="Controls" type="CanvasLayer" parent="."]
 


### PR DESCRIPTION
A few inter-dependent changes to how the wireframe and selection boxes are handled:
- Fix a missing redraw when changing selection (regression caused by a previous PR)
- Remove the extra unnecessary baseline that overhangs
- Display all selection boxes even when the character is not selected (the selected character now receives a brighter highlight)
- The mouse can be used to select characters by clicking on them
- Change the FontImage to be a TextureRect rather than a Sprite2D, to simplify ui input