### PR TITLE
Add character offset support

### DIFF
--- a/components/fnt_file.gd
+++ b/components/fnt_file.gd
@@ -44,20 +44,18 @@ var char_data_keys = [
 ]
 
 
-func add_char(character: String, x, y, width, height, x_advance):
-	var raw_code = character.to_wchar_buffer().hex_encode()
-	var char_id = "0x" + raw_code.substr(2, 2) + raw_code.substr(0, 2)
-	char_id = char_id.hex_to_int()
+func add_char(character: String, pos: Vector2i, size: Vector2i, offset: Vector2i, x_advance: int):
+	var char_id = character.unicode_at(0)
 	
 	file_structure.chars.push_back({
 		"id": int(char_id),
-		"x": int(x),
-		"y": int(y),
-		"width": int(min(width, x_advance)),
-		"height": int(height),
-		"xoffset": 0,
-		"yoffset": 0,
-		"xadvance": int(min(width, x_advance)),
+		"x": pos.x,
+		"y": pos.y,
+		"width": size.x,
+		"height": size.y,
+		"xoffset": offset.x,
+		"yoffset": offset.y,
+		"xadvance": x_advance,
 		"page": 0,
 		"chnl": 15,
 	})
@@ -72,13 +70,16 @@ func add_values(values):
 	file_structure.common.scaleH = values.texture_dimensions.y
 	file_structure.pages[0].file = values.texture_name + "." + values.file_extension
 	
-	var char_count: int =  values.char_list.length()
+	var char_count: int = values.char_list.length()
 	var h_char_count: int = int(values.texture_dimensions.x) / int(values.char_dimensions.x)
 	for i in range(char_count):
 		add_char(values.char_list[i],
-				(i % h_char_count) * values.char_dimensions.x,
-				(i / h_char_count) * values.char_dimensions.y,
-				values.char_dimensions.x, values.char_dimensions.y,
+				Vector2i(
+					(i % h_char_count) * values.char_dimensions.x,
+					(i / h_char_count) * values.char_dimensions.y
+				),
+				values.char_dimensions,
+				values.char_offsets[i],
 				values.advance_infos[i])
 
 
@@ -128,7 +129,7 @@ func export_as_text_to(directory, tex_name) -> bool:
 	
 	var file = FileAccess.open(directory + "/" + tex_name.split(".")[0] + ".fnt", FileAccess.WRITE)
 	if file == null:
-		print(file.get_open_error())
+		print(FileAccess.get_open_error())
 		return false
 
 	file.store_string(fnt_data)
@@ -189,7 +190,7 @@ func export_as_xml_to(directory, tex_name) -> bool:
 	
 	var file = FileAccess.open(directory + "/" + tex_name.split(".")[0] + ".fnt", FileAccess.WRITE)
 	if file == null:
-		print(file.get_open_error())
+		print(FileAccess.get_open_error())
 		return false
 
 	file.store_string(fnt_data)

--- a/components/fnt_file.gd
+++ b/components/fnt_file.gd
@@ -61,7 +61,7 @@ func add_char(character: String, pos: Vector2i, size: Vector2i, offset: Vector2i
 	})
 
 
-func add_values(values):
+func add_values(values: Dictionary) -> void:
 	file_structure.info.face = values.font_name
 	file_structure.info.size = values.char_dimensions.y
 	file_structure.common.lineHeight = values.char_dimensions.y

--- a/components/font_image/font_image.gd
+++ b/components/font_image/font_image.gd
@@ -3,32 +3,30 @@ extends TextureRect
 
 const CHAR_SEPARATOR_COLOR: Color = Color(0, 1.0, 0, 0.5)
 const CHAR_BASE_COLOR: Color = Color(1.0, 0, 0, 0.5)
+const CHAR_OFFSET_POS_COLOR: Color = Color(0, 1.0, 1.0, 0.5)
+const CHAR_OFFSET_NEG_COLOR: Color = Color(1.0, 1.0, 0, 0.5)
 const LETTER_BOX_COLOR := Color(1.0, 1.0, 1.0, 0.25)
 const LETTER_SELECTION_COLOR := Color(1.0, 1.0, 1.0, 0.5)
 
 const MIN_ZOOM_AMOUNT: int = 1
 const MAX_ZOOM_AMOUNT: int = 20
+
+@export var user_interface: UserInterface
+
 var current_zoom_amount: int = 1
 
 var is_texture_set: bool = false
-var texture_dimensions: Vector2 = Vector2(0, 0)
-var draw_from: Vector2 = Vector2(0, 0)
-var base_offset = 0
 
 var is_mouse_pressed: bool = false
 
-var char_counts: Vector2 = Vector2(1, 1)
 var letter_indices := Vector2i(0, 0)
-var char_dimensions: Vector2 = Vector2(1, 1)
-
-var current_char_advance: int = 0
 
 @onready var camera = $"../MainCamera"
 
 
 func set_current_letter(index: int) -> void:
-	letter_indices.x = index % int(char_counts.x)
-	letter_indices.y = floor(index / char_counts.x)
+	letter_indices.x = index % int(user_interface.char_counts.x)
+	letter_indices.y = floor(index / user_interface.char_counts.x)
 	
 	queue_redraw()
 
@@ -70,109 +68,96 @@ func _draw() -> void:
 func _gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:
 		if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-			letter_indices.x = event.position.x / char_dimensions.x
-			letter_indices.y = event.position.y / char_dimensions.y
-			get_parent().user_interface.set_current_char_index(letter_indices.y * char_counts.x + letter_indices.x)
+			letter_indices.x = event.position.x / user_interface.char_dimensions.x
+			letter_indices.y = event.position.y / user_interface.char_dimensions.y
+			user_interface.set_current_char_index(letter_indices.y * user_interface.char_counts.x + letter_indices.x)
 			queue_redraw()
 
 
 func _draw_letter_selection():
-	for j in range(char_counts.y):
-		for i in range(char_counts.x):
+	var char_dimensions = user_interface.char_dimensions
+	for j in range(user_interface.char_counts.y):
+		for i in range(user_interface.char_counts.x):
+			var index = i + j * user_interface.char_counts.x
 			var color = LETTER_BOX_COLOR
 			if letter_indices == Vector2i(i, j):
 				color = LETTER_SELECTION_COLOR
-			draw_rect(Rect2(
-				draw_from.x + (char_dimensions.x * i),
-				draw_from.y + (char_dimensions.y * j),
-				get_parent().user_interface.advance_infos[i + j * char_counts.x],
-				char_dimensions.y
-			), color)
+			var top_left := Vector2i(
+				user_interface.char_dimensions.x * i,
+				user_interface.char_dimensions.y * j
+			)
+			var selection_size := Vector2i(
+				user_interface.advance_infos[index],
+				user_interface.char_dimensions.y
+			)
+			var offset: Vector2i = user_interface.char_offsets[index]
+			draw_rect(
+				Rect2(
+					top_left - offset,
+					selection_size
+				),
+				color
+			)
+			if offset.x != 0:
+				var line_color = CHAR_OFFSET_POS_COLOR
+				if offset.x > 0:
+					offset.x -= char_dimensions.x
+					line_color = CHAR_OFFSET_NEG_COLOR
+				var line_start := top_left - Vector2i(offset.x, 0)
+				draw_line(line_start, line_start + Vector2i(0, char_dimensions.y), line_color)
+			if offset.y != 0:
+				var line_color = CHAR_OFFSET_POS_COLOR
+				if offset.y > 0:
+					offset.y -= char_dimensions.y
+					line_color = CHAR_OFFSET_NEG_COLOR
+				var line_start := top_left - Vector2i(0, offset.y)
+				draw_line(line_start, line_start + Vector2i(char_dimensions.x, 0), line_color)
 
 
 func _draw_base_line():
-	for i in range(char_counts.y):
-		if i == char_counts.y + 1:
+	for i in range(user_interface.char_counts.y):
+		if i == user_interface.char_counts.y + 1:
 			return
 		
 		draw_line(
-			Vector2(draw_from.x, draw_from.y + (char_dimensions.y * i) + base_offset),
+			Vector2(0, (user_interface.char_dimensions.y * i) + user_interface.base_from_top),
 			Vector2(
-				draw_from.x + texture_dimensions.x,
-				draw_from.y + (char_dimensions.y * i) + base_offset
+				user_interface.texture_dimensions.x,
+				(user_interface.char_dimensions.y * i) + user_interface.base_from_top
 			),
 			CHAR_BASE_COLOR,
 		)
 
 
 func _draw_letter_separators():
-	for i in range(char_counts.x + 1):
+	for i in range(user_interface.char_counts.x + 1):
 		draw_line(
-			Vector2(draw_from.x + (char_dimensions.x * i), draw_from.y),
-			Vector2(draw_from.x + (char_dimensions.x * i), draw_from.y + texture_dimensions.y),
+			Vector2((user_interface.char_dimensions.x * i), 0),
+			Vector2((user_interface.char_dimensions.x * i), user_interface.texture_dimensions.y),
 			CHAR_SEPARATOR_COLOR
 		)
 		
-	for i in range(char_counts.y + 1):
+	for i in range(user_interface.char_counts.y + 1):
 		draw_line(
-			Vector2(draw_from.x, draw_from.y + (char_dimensions.y * i)),
-			Vector2(draw_from.x + texture_dimensions.x, draw_from.y + (char_dimensions.y * i)),
+			Vector2(0, user_interface.char_dimensions.y * i),
+			Vector2(user_interface.texture_dimensions.x, user_interface.char_dimensions.y * i),
 			CHAR_SEPARATOR_COLOR
 		)
 
 
-func set_current_char_advance(value: int) -> void:
-	current_char_advance = value
-	
-	queue_redraw()
-
-
-func set_wireframe(options: Dictionary) -> void:
+func update_wireframe() -> void:
 	if not is_texture_set:
 		return
-		
-	if options.has("char_width") and int(options["char_width"]) != char_dimensions.x:
-		char_dimensions.x = options.char_width
-		char_counts.x = get_horizontal_char_count()
-		queue_redraw()
-	
-	if options.has("char_height") and int(options["char_height"]) != char_dimensions.y:
-		char_dimensions.y = options.char_height
-		char_counts.y = get_vertical_char_count()
-		queue_redraw()
-		
-	if options.has("base_from_top") and int(options["base_from_top"]) != base_offset:
-		base_offset = options.base_from_top
-		queue_redraw()
+
+	queue_redraw()
 
 
 func set_image(tex: Texture) -> void:
 	texture = tex
 	
-	texture_dimensions = texture.get_size()
-	
-	pivot_offset = texture_dimensions / 2
-	
-	char_counts.x = get_horizontal_char_count()
-	char_counts.y = get_vertical_char_count()
+	pivot_offset = user_interface.texture_dimensions / 2
 	
 	is_texture_set = true
 	
 	# TODO: Is this required? Unsure what this is meant to do.
 	#queue_redraw()
-
-
-func set_char_width(value: int) -> void:
-	char_dimensions.x = max(1, value)
-
-
-func set_char_height(value: int) -> void:
-	char_dimensions.y = max(1, value)
-
-
-func get_horizontal_char_count() -> int:
-	return int(texture_dimensions.x / char_dimensions.x)
-
-
-func get_vertical_char_count() -> int:
-	return int(texture_dimensions.y / char_dimensions.y)

--- a/components/font_image/font_image.gd
+++ b/components/font_image/font_image.gd
@@ -25,8 +25,9 @@ var letter_indices := Vector2i(0, 0)
 
 
 func set_current_letter(index: int) -> void:
-	letter_indices.x = index % int(user_interface.char_counts.x)
-	letter_indices.y = floor(index / user_interface.char_counts.x)
+	var chars_x: int = user_interface.char_counts.x
+	letter_indices.x = index % chars_x
+	letter_indices.y = index / chars_x
 	
 	queue_redraw()
 
@@ -66,29 +67,33 @@ func _draw() -> void:
 
 
 func _gui_input(event: InputEvent) -> void:
+	var char_dimensions = user_interface.char_dimensions
+	var char_counts = user_interface.char_counts
 	if event is InputEventMouseButton:
 		if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-			letter_indices.x = event.position.x / user_interface.char_dimensions.x
-			letter_indices.y = event.position.y / user_interface.char_dimensions.y
-			user_interface.set_current_char_index(letter_indices.y * user_interface.char_counts.x + letter_indices.x)
+			letter_indices.x = event.position.x / char_dimensions.x
+			letter_indices.y = event.position.y / char_dimensions.y
+			user_interface.set_current_char_index(letter_indices.y * char_counts.x + letter_indices.x)
 			queue_redraw()
 
 
 func _draw_letter_selection():
 	var char_dimensions = user_interface.char_dimensions
-	for j in range(user_interface.char_counts.y):
-		for i in range(user_interface.char_counts.x):
-			var index = i + j * user_interface.char_counts.x
+	var char_counts = user_interface.char_counts
+	var char_offsets = user_interface.char_offsets
+	for j in range(char_counts.y):
+		for i in range(char_counts.x):
+			var index = i + j * char_counts.x
 			var color = LETTER_BOX_COLOR
 			if letter_indices == Vector2i(i, j):
 				color = LETTER_SELECTION_COLOR
 			var top_left := Vector2i(
-				user_interface.char_dimensions.x * i,
-				user_interface.char_dimensions.y * j
+				char_dimensions.x * i,
+				char_dimensions.y * j
 			)
 			var selection_size := Vector2i(
 				user_interface.advance_infos[index],
-				user_interface.char_dimensions.y
+				char_dimensions.y
 			)
 			var offset: Vector2i = user_interface.char_offsets[index]
 			draw_rect(
@@ -115,32 +120,39 @@ func _draw_letter_selection():
 
 
 func _draw_base_line():
-	for i in range(user_interface.char_counts.y):
-		if i == user_interface.char_counts.y + 1:
+	var char_counts = user_interface.char_counts
+	var char_dimensions = user_interface.char_dimensions
+	var texture_dimensions = user_interface.texture_dimensions
+	var base_from_top = user_interface.base_from_top
+	for i in range(char_counts.y):
+		if i == char_counts.y + 1:
 			return
 		
 		draw_line(
-			Vector2(0, (user_interface.char_dimensions.y * i) + user_interface.base_from_top),
+			Vector2(0, (char_dimensions.y * i) + base_from_top),
 			Vector2(
-				user_interface.texture_dimensions.x,
-				(user_interface.char_dimensions.y * i) + user_interface.base_from_top
+				texture_dimensions.x,
+				(char_dimensions.y * i) + base_from_top
 			),
 			CHAR_BASE_COLOR,
 		)
 
 
 func _draw_letter_separators():
-	for i in range(user_interface.char_counts.x + 1):
+	var char_counts = user_interface.char_counts
+	var char_dimensions = user_interface.char_dimensions
+	var texture_dimensions = user_interface.texture_dimensions
+	for i in range(char_counts.x + 1):
 		draw_line(
-			Vector2((user_interface.char_dimensions.x * i), 0),
-			Vector2((user_interface.char_dimensions.x * i), user_interface.texture_dimensions.y),
+			Vector2((char_dimensions.x * i), 0),
+			Vector2((char_dimensions.x * i), texture_dimensions.y),
 			CHAR_SEPARATOR_COLOR
 		)
 		
-	for i in range(user_interface.char_counts.y + 1):
+	for i in range(char_counts.y + 1):
 		draw_line(
-			Vector2(0, user_interface.char_dimensions.y * i),
-			Vector2(user_interface.texture_dimensions.x, user_interface.char_dimensions.y * i),
+			Vector2(0, char_dimensions.y * i),
+			Vector2(texture_dimensions.x, char_dimensions.y * i),
 			CHAR_SEPARATOR_COLOR
 		)
 

--- a/components/user_interface/dimensions.gd
+++ b/components/user_interface/dimensions.gd
@@ -1,0 +1,33 @@
+extends HBoxContainer
+
+signal value_changed(value: Vector2i)
+signal x_changed(value: int)
+signal y_changed(value: int)
+
+@export var allow_negative := false
+
+var value := Vector2i.ZERO:
+	set(new_value):
+		value = new_value
+		x_edit.value = value.x
+		y_edit.value = value.y
+
+@onready var x_edit: SpinBox = %XEdit
+@onready var y_edit: SpinBox = %YEdit
+
+
+func _ready() -> void:
+	x_edit.allow_lesser = allow_negative
+	y_edit.allow_lesser = allow_negative
+
+
+func _on_x_edit_value_changed(x_val: float) -> void:
+	x_changed.emit(x_val)
+	value.x = x_val
+	value_changed.emit(value)
+
+
+func _on_y_edit_value_changed(y_val: float) -> void:
+	y_changed.emit(y_val)
+	value.y = y_val
+	value_changed.emit(value)

--- a/components/user_interface/dimensions.tscn
+++ b/components/user_interface/dimensions.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=2 format=3 uid="uid://d3he1bo7l206j"]
+
+[ext_resource type="Script" path="res://components/user_interface/dimensions.gd" id="1_hhfng"]
+
+[node name="Dimensions" type="HBoxContainer"]
+theme_override_constants/separation = 8
+script = ExtResource("1_hhfng")
+
+[node name="X" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="XEdit" type="SpinBox" parent="X"]
+unique_name_in_owner = true
+layout_mode = 2
+rounded = true
+allow_greater = true
+
+[node name="Pixels" type="Label" parent="X"]
+layout_mode = 2
+text = "px"
+
+[node name="Times" type="Label" parent="."]
+layout_mode = 2
+text = "X"
+
+[node name="Y" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="YEdit" type="SpinBox" parent="Y"]
+unique_name_in_owner = true
+layout_mode = 2
+rounded = true
+allow_greater = true
+
+[node name="Pixels" type="Label" parent="Y"]
+layout_mode = 2
+text = "px"
+
+[connection signal="value_changed" from="X/XEdit" to="." method="_on_x_edit_value_changed"]
+[connection signal="value_changed" from="Y/YEdit" to="." method="_on_y_edit_value_changed"]

--- a/components/user_interface/user_interface.gd
+++ b/components/user_interface/user_interface.gd
@@ -3,10 +3,10 @@ extends HBoxContainer
 
 
 signal form_field_updated()
-signal export_button_pressed()
+signal export_button_pressed(new_values: Dictionary)
 signal export_as_xml_button_pressed()
-signal selected_char_index_changed(new_index)
-signal file_selected(texture_info)
+signal selected_char_index_changed(new_index: int)
+signal file_selected(texture_info: Dictionary)
 
 const MAX_CHAR_RESOLUTION: int = 256
 const MIN_CHAR_RESOLUTION: int = 8
@@ -219,7 +219,7 @@ func _on_base_edit_value_changed(value: float) -> void:
 	form_field_updated.emit()
 
 
-func _get_export_values():
+func _get_export_values() -> Dictionary:
 	return {
 		"font_name": font_name_edit.text,
 		"texture_name": texture_name_edit.text,
@@ -234,7 +234,7 @@ func _get_export_values():
 
 
 func _on_export_button_pressed() -> void:
-	var export_values = _get_export_values()
+	var export_values: Dictionary = _get_export_values()
 	
 	export_button_pressed.emit(export_values)
 

--- a/components/user_interface/user_interface.gd
+++ b/components/user_interface/user_interface.gd
@@ -1,10 +1,11 @@
+class_name UserInterface
 extends HBoxContainer
 
 
-signal form_field_updated(new_values)
+signal form_field_updated()
 signal export_button_pressed()
 signal export_as_xml_button_pressed()
-signal selected_char_index_changed(new_index, char_advance)
+signal selected_char_index_changed(new_index)
 signal file_selected(texture_info)
 
 const MAX_CHAR_RESOLUTION: int = 256
@@ -12,11 +13,15 @@ const MIN_CHAR_RESOLUTION: int = 8
 const MAX_ADVANCE_INFO_COUNT: int = 1025
 
 var current_char_atlas: AtlasTexture = null
-var texture_dimensions: Vector2 = Vector2(0, 0)
-var char_counts: Vector2 = Vector2(1, 1)
+var texture_dimensions := Vector2i.ZERO
+var char_counts := Vector2i.ONE
+var char_dimensions := Vector2i.ZERO
 
-var advance_infos: Array = []
+var advance_infos: PackedInt32Array = []
+var char_offsets: Array[Vector2i] = []
 var current_char_index: int = 0
+
+var base_from_top := 0
 
 var texture_file_extension: String = ""
 
@@ -25,15 +30,15 @@ var texture_file_extension: String = ""
 @onready var current_char_rect = %SelectedChar
 @onready var current_char_advance = %CurrentAdvance
 @onready var current_advance_edit = %CurrentAdvanceEdit
+@onready var char_dimensions_edit = %CharDimensionsEdit
+@onready var current_offset_edit = %CurrentOffsetEdit
 @onready var advance_limit_label = %AdvanceLimit
 @onready var current_char_edit = %CurrentChar
 @onready var char_count_label = %CharCount
 
 @onready var font_name_edit = %FontNameEdit
 @onready var texture_name_edit = %TextureNameEdit
-@onready var char_width_edit = %CharWidthEdit
-@onready var char_height_edit = %CharHeightEdit
-@onready var base_value_edit = %BaseValue
+@onready var base_edit = %BaseEdit
 @onready var char_list_edit = %CharListEdit
 
 @onready var info_dialog = %InfoDialog
@@ -48,27 +53,17 @@ func _ready() -> void:
 	
 	current_char_atlas = AtlasTexture.new()
 	
-	for i in range(MAX_ADVANCE_INFO_COUNT):
-		advance_infos.push_back(0)
+	advance_infos.resize(MAX_ADVANCE_INFO_COUNT)
+	char_offsets.resize(MAX_ADVANCE_INFO_COUNT)
+	char_offsets.fill(Vector2i.ZERO)
 
 
 func open_overwrite_confirm_dialog():
 	overwrite_dialog.popup_centered()
 
 
-func set_char_width(value: int) -> void:
-	char_width_edit.text = str(value)
-	_on_char_width_edit_focus_exited()
-
-
-func set_char_height(value: int) -> void:
-	char_height_edit.text = str(value)
-	_on_char_height_edit_focus_exited()
-
-
-func set_base_from_top(value: int) -> void:
-	base_value_edit.text = str(value)
-	_on_base_value_edit_focus_exited()
+func set_char_dimensions(value: Vector2i) -> void:
+	char_dimensions_edit.value = value
 
 
 func set_current_char(value: int) -> void:
@@ -132,17 +127,22 @@ func _on_file_selected(file_path: String) -> void:
 
 
 func _update_current_visible_char():
+	var pos = Vector2i(current_char_index % char_counts.x, current_char_index / char_counts.x)
 	current_char_atlas.region = Rect2(
-		(int(current_char_index % int(char_counts.x))) * int(char_width_edit.text),
-		(int(current_char_index / char_counts.x)) * int(char_height_edit.text),
-		int(char_width_edit.text),
-		int(char_height_edit.text)
+		pos * char_dimensions,
+		char_dimensions,
 	)
 	
 	var selected_index = min(current_char_index, advance_infos.size() - 1)
 	
+	current_offset_edit.value = char_offsets[selected_index]
 	current_advance_edit.text = str(advance_infos[selected_index])
 	current_char_edit.text = str(selected_index)
+	
+	current_char_rect.offset_left = char_offsets[selected_index].x
+	current_char_rect.offset_right = char_offsets[selected_index].x
+	current_char_rect.offset_top = char_offsets[selected_index].y
+	current_char_rect.offset_bottom = char_offsets[selected_index].y
 	
 	current_char_rect.custom_minimum_size.x = advance_infos[selected_index]
 	current_char_rect.custom_minimum_size.y = advance_infos[selected_index]
@@ -156,16 +156,14 @@ func _on_image_load_button_pressed() -> void:
 
 
 func _on_char_advance_edit_focus_exited() -> void:
-	var char_advance = min(int(char_width_edit.text), int(current_advance_edit.text))
+	var char_advance = min(char_dimensions.x, int(current_advance_edit.text))
 	char_advance = max(char_advance, 0)
 	
 	advance_infos[current_char_index] = char_advance
 	
 	_update_current_visible_char()
 	
-	form_field_updated.emit({
-		"current_char_advance": advance_infos[current_char_index],
-	})
+	form_field_updated.emit()
 
 
 func _on_current_char_edit_focus_exited() -> void:
@@ -174,67 +172,18 @@ func _on_current_char_edit_focus_exited() -> void:
 	
 	_update_current_visible_char()
 	
-	selected_char_index_changed.emit(current_char_index, advance_infos[current_char_index])
-
-
-func _on_char_width_edit_focus_exited() -> void:
-	var char_width = max(MIN_CHAR_RESOLUTION, int(char_width_edit.text))
-	char_width = min(MAX_CHAR_RESOLUTION, char_width)
-	char_width_edit.text = str(char_width)
-	char_counts.x = max(1, int(texture_dimensions.x / char_width))
-	_update_char_count()
-	current_char_edit.text = str(min(
-			int(current_char_edit.text), int(char_count_label.text)))
-	
-	for i in range(MAX_ADVANCE_INFO_COUNT):
-		advance_infos[i] = min(char_width, advance_infos[i])
-		
-	advance_limit_label.text = str(char_width)
-		
-	_update_current_visible_char()
-	
-	form_field_updated.emit({
-		"char_width": char_width,
-	})
-
-
-func _on_char_height_edit_focus_exited() -> void:
-	var char_height = max(MIN_CHAR_RESOLUTION, int(char_height_edit.text))
-	char_height = min(MAX_CHAR_RESOLUTION, char_height)
-	char_height_edit.text = str(char_height)
-	char_counts.y = max(1, int(texture_dimensions.y / char_height))
-	_update_char_count()
-	current_char_edit.text = str(min(
-			int(current_char_edit.text), int(char_count_label.text)))
-	
-	_update_current_visible_char()
-	
-	form_field_updated.emit({
-		"char_height": char_height,
-	})
-
-
-func _on_decrease_base_button_pressed() -> void:
-	base_value_edit.text = str(max(0, int(base_value_edit.text) - 1))
-	form_field_updated.emit({"base_from_top": int(base_value_edit.text)})
-
-
-func _on_increase_base_button_pressed() -> void:
-	base_value_edit.text = str(min(int(base_value_edit.text) + 1, int(char_height_edit.text)))
-	form_field_updated.emit({"base_from_top": int(base_value_edit.text)})
+	selected_char_index_changed.emit(current_char_index)
 
 
 func _on_increase_advance_button_pressed() -> void:
 	advance_infos[current_char_index] = min(
 			advance_infos[current_char_index] + 1,
-			int(char_width_edit.text)
+			char_dimensions.x
 		)
 		
 	_update_current_visible_char()
 	
-	form_field_updated.emit({
-		"current_char_advance": advance_infos[current_char_index],
-	})
+	form_field_updated.emit()
 
 
 func _on_decrease_advance_button_pressed() -> void:
@@ -245,9 +194,7 @@ func _on_decrease_advance_button_pressed() -> void:
 	
 	_update_current_visible_char()
 	
-	form_field_updated.emit({
-		"current_char_advance": advance_infos[current_char_index],
-	})
+	form_field_updated.emit()
 
 
 func _on_prev_char_button_pressed() -> void:
@@ -261,29 +208,26 @@ func _on_next_char_button_pressed() -> void:
 ## Set the selected character index
 func set_current_char_index(index: int) -> void:
 	current_char_index = clamp(index, 0, (char_counts.x * char_counts.y) - 1)
-	selected_char_index_changed.emit(current_char_index, advance_infos[current_char_index])
+	selected_char_index_changed.emit(current_char_index)
 	current_char_edit.text = str(current_char_index)
 	_update_current_visible_char()
 
 
-func _on_base_value_edit_focus_exited() -> void:
-	var parsed_value = int(base_value_edit.text)
-	parsed_value = max(0, parsed_value)
-	parsed_value = min(int(char_height_edit.text), parsed_value)
+func _on_base_edit_value_changed(value: float) -> void:
+	base_from_top = value
 	
-	base_value_edit.text = str(parsed_value)
-	
-	form_field_updated.emit({"base_from_top": parsed_value})
+	form_field_updated.emit()
 
 
 func _get_export_values():
 	return {
 		"font_name": font_name_edit.text,
 		"texture_name": texture_name_edit.text,
-		"char_dimensions": Vector2(int(char_width_edit.text), int(char_height_edit.text)),
+		"char_dimensions": char_dimensions,
 		"texture_dimensions": texture_dimensions,
-		"base_from_top": int(base_value_edit.text),
+		"base_from_top": base_edit.value,
 		"char_list": char_list_edit.text,
+		"char_offsets": char_offsets.slice(0, char_list_edit.text.length()),
 		"advance_infos": advance_infos.slice(0, char_list_edit.text.length()),
 		"file_extension": texture_file_extension,
 	}
@@ -299,3 +243,28 @@ func _on_export_as_xml_button_pressed() -> void:
 	var export_values = _get_export_values()
 	
 	export_as_xml_button_pressed.emit(export_values)
+
+
+func _on_current_offset_edit_value_changed(value: Vector2i) -> void:
+	char_offsets[current_char_index] = value
+	
+	_update_current_visible_char()
+	
+	form_field_updated.emit()
+
+
+func _on_char_dimensions_edit_value_changed(value: Vector2i) -> void:
+	char_dimensions = value
+	char_counts = texture_dimensions / char_dimensions
+	_update_char_count()
+	current_char_edit.text = str(min(
+			int(current_char_edit.text), int(char_count_label.text)))
+	
+	for i in range(MAX_ADVANCE_INFO_COUNT):
+		advance_infos[i] = min(char_dimensions.x, advance_infos[i])
+	
+	advance_limit_label.text = str(char_dimensions.x)
+	
+	_update_current_visible_char()
+	
+	form_field_updated.emit()

--- a/components/user_interface/user_interface.tscn
+++ b/components/user_interface/user_interface.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://rcj2mnv6rwrf"]
+[gd_scene load_steps=4 format=3 uid="uid://rcj2mnv6rwrf"]
 
 [ext_resource type="Script" path="res://components/user_interface/user_interface.gd" id="2"]
+[ext_resource type="PackedScene" uid="uid://d3he1bo7l206j" path="res://components/user_interface/dimensions.tscn" id="2_gv6df"]
 
 [sub_resource type="AtlasTexture" id="1"]
 
@@ -44,62 +45,76 @@ modulate = Color(1, 1, 1, 0.498039)
 layout_mode = 2
 size_flags_horizontal = 0
 
-[node name="Items" type="VBoxContainer" parent="AdvancePanel/LetterControl/Controls"]
+[node name="AdvanceControls" type="VBoxContainer" parent="AdvancePanel/LetterControl/Controls"]
 layout_mode = 2
 
-[node name="XAdvance" type="Label" parent="AdvancePanel/LetterControl/Controls/Items"]
+[node name="XAdvanceLabel" type="Label" parent="AdvancePanel/LetterControl/Controls/AdvanceControls"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "X Advance"
 horizontal_alignment = 1
 
-[node name="Edit" type="HBoxContainer" parent="AdvancePanel/LetterControl/Controls/Items"]
+[node name="Edit" type="HBoxContainer" parent="AdvancePanel/LetterControl/Controls/AdvanceControls"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="CurrentAdvanceEdit" type="LineEdit" parent="AdvancePanel/LetterControl/Controls/Items/Edit"]
+[node name="CurrentAdvanceEdit" type="LineEdit" parent="AdvancePanel/LetterControl/Controls/AdvanceControls/Edit"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "0"
 
-[node name="Pixels2" type="Label" parent="AdvancePanel/LetterControl/Controls/Items/Edit"]
+[node name="Pixels2" type="Label" parent="AdvancePanel/LetterControl/Controls/AdvanceControls/Edit"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "px"
 horizontal_alignment = 1
 
-[node name="Slash" type="Label" parent="AdvancePanel/LetterControl/Controls/Items/Edit"]
+[node name="Slash" type="Label" parent="AdvancePanel/LetterControl/Controls/AdvanceControls/Edit"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "/"
 horizontal_alignment = 1
 
-[node name="AdvanceLimit" type="Label" parent="AdvancePanel/LetterControl/Controls/Items/Edit"]
+[node name="AdvanceLimit" type="Label" parent="AdvancePanel/LetterControl/Controls/AdvanceControls/Edit"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "10"
 horizontal_alignment = 1
 
-[node name="Pixels" type="Label" parent="AdvancePanel/LetterControl/Controls/Items/Edit"]
+[node name="Pixels" type="Label" parent="AdvancePanel/LetterControl/Controls/AdvanceControls/Edit"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "px"
 horizontal_alignment = 1
 
-[node name="Buttons" type="HBoxContainer" parent="AdvancePanel/LetterControl/Controls/Items"]
+[node name="Buttons" type="HBoxContainer" parent="AdvancePanel/LetterControl/Controls/AdvanceControls"]
 layout_mode = 2
 
-[node name="Decrease" type="Button" parent="AdvancePanel/LetterControl/Controls/Items/Buttons"]
+[node name="Decrease" type="Button" parent="AdvancePanel/LetterControl/Controls/AdvanceControls/Buttons"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "<"
 
-[node name="Increase" type="Button" parent="AdvancePanel/LetterControl/Controls/Items/Buttons"]
+[node name="Increase" type="Button" parent="AdvancePanel/LetterControl/Controls/AdvanceControls/Buttons"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = ">"
+
+[node name="OffsetControls" type="VBoxContainer" parent="AdvancePanel/LetterControl/Controls"]
+layout_mode = 2
+
+[node name="OffsetLabel" type="Label" parent="AdvancePanel/LetterControl/Controls/OffsetControls"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Offset"
+horizontal_alignment = 1
+
+[node name="CurrentOffsetEdit" parent="AdvancePanel/LetterControl/Controls/OffsetControls" instance=ExtResource("2_gv6df")]
+unique_name_in_owner = true
+layout_mode = 2
+allow_negative = true
 
 [node name="Index" type="Label" parent="AdvancePanel/LetterControl/Controls"]
 layout_mode = 2
@@ -224,37 +239,9 @@ layout_mode = 2
 layout_mode = 2
 text = "CHAR_DIMENSIONS"
 
-[node name="CharDimensions" type="HBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions"]
-layout_mode = 2
-theme_override_constants/separation = 8
-
-[node name="X" type="HBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions"]
-layout_mode = 2
-
-[node name="CharWidthEdit" type="LineEdit" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/X"]
+[node name="CharDimensionsEdit" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions" instance=ExtResource("2_gv6df")]
 unique_name_in_owner = true
 layout_mode = 2
-text = "1"
-
-[node name="Pixels" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/X"]
-layout_mode = 2
-text = "px"
-
-[node name="Times" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions"]
-layout_mode = 2
-text = "X"
-
-[node name="Y" type="HBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions"]
-layout_mode = 2
-
-[node name="CharHeightEdit" type="LineEdit" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/Y"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "1"
-
-[node name="Pixels" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/Y"]
-layout_mode = 2
-text = "px"
 
 [node name="BaseFromTop" type="VBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items"]
 layout_mode = 2
@@ -266,22 +253,15 @@ text = "BASE_FROM_TOP"
 [node name="BaseSettings" type="HBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop"]
 layout_mode = 2
 
-[node name="DecreaseButton" type="Button" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings"]
-layout_mode = 2
-text = "<"
-
-[node name="BaseValue" type="LineEdit" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings"]
+[node name="BaseEdit" type="SpinBox" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "0"
+rounded = true
+allow_greater = true
 
-[node name="Pixels3" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings"]
+[node name="Pixels" type="Label" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings"]
 layout_mode = 2
 text = "px"
-
-[node name="IncreaseButton" type="Button" parent="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings"]
-layout_mode = 2
-text = ">"
 
 [node name="CharList" type="VBoxContainer" parent="RightSide/FontInfo/Scroll/Margin/Items"]
 layout_mode = 2
@@ -322,18 +302,16 @@ dialog_text = "Dialog message."
 unique_name_in_owner = true
 dialog_text = "FILE_EXISTS"
 
-[connection signal="focus_exited" from="AdvancePanel/LetterControl/Controls/Items/Edit/CurrentAdvanceEdit" to="." method="_on_char_advance_edit_focus_exited"]
-[connection signal="pressed" from="AdvancePanel/LetterControl/Controls/Items/Buttons/Decrease" to="." method="_on_decrease_advance_button_pressed"]
-[connection signal="pressed" from="AdvancePanel/LetterControl/Controls/Items/Buttons/Increase" to="." method="_on_increase_advance_button_pressed"]
+[connection signal="focus_exited" from="AdvancePanel/LetterControl/Controls/AdvanceControls/Edit/CurrentAdvanceEdit" to="." method="_on_char_advance_edit_focus_exited"]
+[connection signal="pressed" from="AdvancePanel/LetterControl/Controls/AdvanceControls/Buttons/Decrease" to="." method="_on_decrease_advance_button_pressed"]
+[connection signal="pressed" from="AdvancePanel/LetterControl/Controls/AdvanceControls/Buttons/Increase" to="." method="_on_increase_advance_button_pressed"]
+[connection signal="value_changed" from="AdvancePanel/LetterControl/Controls/OffsetControls/CurrentOffsetEdit" to="." method="_on_current_offset_edit_value_changed"]
 [connection signal="pressed" from="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering/Controls/PrevChar" to="." method="_on_prev_char_button_pressed"]
 [connection signal="focus_exited" from="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering/Controls/CurrentChar" to="." method="_on_current_char_edit_focus_exited"]
 [connection signal="pressed" from="AdvancePanel/LetterControl/Controls/LetterSwitch/Centering/Controls/NextChar" to="." method="_on_next_char_button_pressed"]
 [connection signal="pressed" from="RightSide/TextureInfo/Margin/Items/Title/ImageLoad" to="." method="_on_image_load_button_pressed"]
-[connection signal="focus_exited" from="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/X/CharWidthEdit" to="." method="_on_char_width_edit_focus_exited"]
-[connection signal="focus_exited" from="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensions/Y/CharHeightEdit" to="." method="_on_char_height_edit_focus_exited"]
-[connection signal="pressed" from="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings/DecreaseButton" to="." method="_on_decrease_base_button_pressed"]
-[connection signal="focus_exited" from="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings/BaseValue" to="." method="_on_base_value_edit_focus_exited"]
-[connection signal="pressed" from="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings/IncreaseButton" to="." method="_on_increase_base_button_pressed"]
+[connection signal="value_changed" from="RightSide/FontInfo/Scroll/Margin/Items/CharDimensions/CharDimensionsEdit" to="." method="_on_char_dimensions_edit_value_changed"]
+[connection signal="value_changed" from="RightSide/FontInfo/Scroll/Margin/Items/BaseFromTop/BaseSettings/BaseEdit" to="." method="_on_base_edit_value_changed"]
 [connection signal="pressed" from="RightSide/FontInfo/Scroll/Margin/Items/Export/ExportButton" to="." method="_on_export_button_pressed"]
 [connection signal="pressed" from="RightSide/FontInfo/Scroll/Margin/Items/Export/ExportAsXMLButton" to="." method="_on_export_as_xml_button_pressed"]
 [connection signal="file_selected" from="OpenFile" to="." method="_on_file_selected"]

--- a/scenes/main/main.gd
+++ b/scenes/main/main.gd
@@ -59,25 +59,17 @@ func _on_file_selected(tex_info: Dictionary) -> void:
 	
 	export_directory = tex_info.texture_directory
 	
-	user_interface.set_char_width(texture_size.x / 2)
-	user_interface.set_char_height(texture_size.y / 2)
+	user_interface.set_char_dimensions(texture_size / 2)
 	
-	font_image.set_wireframe({
-		"char_width": texture_size.x / 2,
-		"char_height": texture_size.y / 2,
-	})
+	font_image.update_wireframe()
 
 
-func _on_form_field_updated(new_values):
-	if new_values.has("current_char_advance"):
-		font_image.set_current_char_advance(new_values.current_char_advance)
-		
-	font_image.set_wireframe(new_values)
+func _on_form_field_updated():
+	font_image.update_wireframe()
 
 
-func _on_selected_char_index_changed(new_index, char_advance):
+func _on_selected_char_index_changed(new_index):
 	font_image.set_current_letter(new_index)
-	font_image.set_current_char_advance(char_advance)
 
 
 func _on_export_button_pressed(export_values):

--- a/scenes/main/main.tscn
+++ b/scenes/main/main.tscn
@@ -8,7 +8,8 @@
 [node name="Main" type="Node2D"]
 script = ExtResource("1")
 
-[node name="FontImage" parent="." instance=ExtResource("3")]
+[node name="FontImage" parent="." node_paths=PackedStringArray("user_interface") instance=ExtResource("3")]
+user_interface = NodePath("../Controls/UserInterface")
 
 [node name="MainCamera" parent="." instance=ExtResource("2")]
 


### PR DESCRIPTION
Adds support for setting the X and Y offsets of individual characters. These are displayed on the wireframe as yellow lines when the offset is positive, and blue lines when the offset is negative.

The pull request also includes some related UI changes, such as replacing number inputs with SpinBoxes, and combining vector inputs into one reusable scene - `dimensions.tscn`.

The associated code was also simplified by referencing `user_interface` directly in the draw functions, rather than passing data around via the `form_field_updated` signal.