### PR TITLE
Lowered minimum char resolution

### DIFF
--- a/components/user_interface/user_interface.gd
+++ b/components/user_interface/user_interface.gd
@@ -9,7 +9,7 @@ signal selected_char_index_changed(new_index: int)
 signal file_selected(texture_info: Dictionary)
 
 const MAX_CHAR_RESOLUTION: int = 256
-const MIN_CHAR_RESOLUTION: int = 8
+const MIN_CHAR_RESOLUTION: int = 5
 const MAX_ADVANCE_INFO_COUNT: int = 1025
 
 var current_char_atlas: AtlasTexture = null


### PR DESCRIPTION
- Ran into an issue where the min char resolution didn't allow me to create the font I wanted, so I lowered it.
- In future, Potentially consider setting the lower bound to 1, or removing it entirely? I'm not sure why this limitation is here.